### PR TITLE
Configure MessageListenerContainer by ConsumerProperties.

### DIFF
--- a/spring-cloud-stream-binder-artemis/src/main/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-artemis/src/main/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinder.java
@@ -94,7 +94,7 @@ public class ArtemisMessageChannelBinder extends
         String subscriptionName = getQueueName(destination.getName(), group);
         ListenerContainerFactory listenerContainerFactory = new ListenerContainerFactory(connectionFactory);
         AbstractMessageListenerContainer listenerContainer = listenerContainerFactory
-                .getListenerContainer(destination.getName(), subscriptionName);
+                .getListenerContainer(destination.getName(), subscriptionName, properties);
 
         if (properties.getMaxAttempts() == 1) {
             return Jms.messageDrivenChannelAdapter(listenerContainer).get();

--- a/spring-cloud-stream-binder-artemis/src/main/java/me/snowdrop/stream/binder/artemis/listener/ListenerContainerFactory.java
+++ b/spring-cloud-stream-binder-artemis/src/main/java/me/snowdrop/stream/binder/artemis/listener/ListenerContainerFactory.java
@@ -16,6 +16,8 @@
 
 package me.snowdrop.stream.binder.artemis.listener;
 
+import me.snowdrop.stream.binder.artemis.properties.ArtemisConsumerProperties;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
@@ -32,7 +34,8 @@ public class ListenerContainerFactory {
         this.connectionFactory = connectionFactory;
     }
 
-    public AbstractMessageListenerContainer getListenerContainer(String topic, String subscriptionName) {
+    public AbstractMessageListenerContainer getListenerContainer(String topic, String subscriptionName,
+            ExtendedConsumerProperties<ArtemisConsumerProperties> properties) {
         DefaultMessageListenerContainer listenerContainer = new DefaultMessageListenerContainer();
         listenerContainer.setConnectionFactory(connectionFactory);
         listenerContainer.setPubSubDomain(true);
@@ -41,6 +44,8 @@ public class ListenerContainerFactory {
         listenerContainer.setSessionTransacted(true);
         listenerContainer.setSubscriptionDurable(true);
         listenerContainer.setSubscriptionShared(true);
+        listenerContainer.setConcurrentConsumers(properties.getConcurrency());
+        listenerContainer.setAutoStartup(properties.isAutoStartup());
         return listenerContainer;
     }
 

--- a/spring-cloud-stream-binder-artemis/src/test/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinderTest.java
+++ b/spring-cloud-stream-binder-artemis/src/test/java/me/snowdrop/stream/binder/artemis/ArtemisMessageChannelBinderTest.java
@@ -50,6 +50,7 @@ public class ArtemisMessageChannelBinderTest {
     @Test
     public void shouldCreateRegularConsumerEndpoint() {
         given(mockConsumerProperties.getMaxAttempts()).willReturn(1);
+        given(mockConsumerProperties.getConcurrency()).willReturn(1);
 
         ArtemisConsumerDestination destination = new ArtemisConsumerDestination("test-destination");
         MessageProducer producer = binder.createConsumerEndpoint(destination, "test-group", mockConsumerProperties);
@@ -63,6 +64,7 @@ public class ArtemisMessageChannelBinderTest {
     @Test
     public void shouldCreateRetryableConsumerEndpoint() {
         given(mockConsumerProperties.getMaxAttempts()).willReturn(2);
+        given(mockConsumerProperties.getConcurrency()).willReturn(1);
 
         ArtemisConsumerDestination destination = new ArtemisConsumerDestination("test-destination");
         MessageProducer producer = binder.createConsumerEndpoint(destination, "test-group", mockConsumerProperties);

--- a/spring-cloud-stream-binder-artemis/src/test/java/me/snowdrop/stream/binder/artemis/listener/ListenerContainerFactoryTest.java
+++ b/spring-cloud-stream-binder-artemis/src/test/java/me/snowdrop/stream/binder/artemis/listener/ListenerContainerFactoryTest.java
@@ -2,31 +2,37 @@ package me.snowdrop.stream.binder.artemis.listener;
 
 import javax.jms.ConnectionFactory;
 
-import org.junit.Before;
+import me.snowdrop.stream.binder.artemis.properties.ArtemisConsumerProperties;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ListenerContainerFactoryTest {
 
     @Mock
     private ConnectionFactory mockConnectionFactory;
 
-    @Before
-    public void before() {
-        MockitoAnnotations.initMocks(this);
-    }
+    @Mock
+    private ArtemisConsumerProperties artemisConsumerProperties;
 
     @Test
     public void shouldGetListenerContainer() {
+        ExtendedConsumerProperties<ArtemisConsumerProperties> properties = new ExtendedConsumerProperties<>(artemisConsumerProperties);
+        properties.setAutoStartup(true);
+        properties.setConcurrency(10);
+
         ListenerContainerFactory factory = new ListenerContainerFactory(mockConnectionFactory);
-        AbstractMessageListenerContainer container = factory.getListenerContainer("testTopic", "testSubscription");
+        AbstractMessageListenerContainer container = factory.getListenerContainer("testTopic", "testSubscription", properties);
         assertThat(container.getConnectionFactory()).isEqualTo(mockConnectionFactory);
         assertThat(container.getDestinationName()).isEqualTo("testTopic");
         assertThat(container.isPubSubDomain()).isTrue();
@@ -34,6 +40,9 @@ public class ListenerContainerFactoryTest {
         assertThat(container.isSessionTransacted()).isTrue();
         assertThat(container.isSubscriptionDurable()).isTrue();
         assertThat(container.isSubscriptionShared()).isTrue();
-    }
+        assertThat(container.isAutoStartup()).isTrue();
 
+        DefaultMessageListenerContainer defaultMessageListenerContainer = (DefaultMessageListenerContainer) container;
+        assertThat(defaultMessageListenerContainer.getConcurrentConsumers()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
Hi,

Salman Khandu <salmankhandu91@gmail.com> asked me about a problem he had with the library. https://stackoverflow.com/questions/69753400/spring-cloud-stream-artemis-binder-concurrency-not-working

I think i found the sollution, the spring cloud stream concurrency property  (spring.cloud.stream.bindings.{{name}}.consumer.concurrency) is not used in the configuration of the `DefaultMessageListenerContainer`.

Not sure how to test it with IntegrationTest, but i tried it with dummy application run against Artemis and its seems to work fine.